### PR TITLE
Use a dark cross on light-coloured regions

### DIFF
--- a/lib/ui/features/game/views/game_view.dart
+++ b/lib/ui/features/game/views/game_view.dart
@@ -714,6 +714,12 @@ class _QueensCellState extends ConsumerState<QueensCell> with TickerProviderStat
   Widget _buildContent() {
     const Color activeIconColor = AppColors.headingDark;
 
+    // A white cross washes out on light regions such as yellow, so flip the
+    // marker (and its drop shadow) to dark on those cells.
+    final bool onLightRegion = widget.regionColor.computeLuminance() > 0.6;
+    final Color crossColor =
+        onLightRegion ? AppColors.headingWhite : activeIconColor;
+
     if (widget.cellState == CellState.queen) {
       return ScaleTransition(
         scale: _scaleAnimation,
@@ -762,12 +768,12 @@ class _QueensCellState extends ConsumerState<QueensCell> with TickerProviderStat
         child: Icon(
           Icons.close_rounded,
           size: 22,
-          color: activeIconColor,
-          shadows: const [
+          color: crossColor,
+          shadows: [
             Shadow(
-              color: Colors.black54,
+              color: onLightRegion ? Colors.white54 : Colors.black54,
               blurRadius: 4.0,
-              offset: Offset(0, 1),
+              offset: const Offset(0, 1),
             ),
           ],
         ),
@@ -779,12 +785,12 @@ class _QueensCellState extends ConsumerState<QueensCell> with TickerProviderStat
         child: Icon(
           Icons.close_rounded,
           size: 16,
-          color: activeIconColor.withValues(alpha: 0.75),
-          shadows: const [
+          color: crossColor.withValues(alpha: 0.75),
+          shadows: [
             Shadow(
-              color: Colors.black45,
+              color: onLightRegion ? Colors.white54 : Colors.black45,
               blurRadius: 3.0,
-              offset: Offset(0, 1),
+              offset: const Offset(0, 1),
             ),
           ],
         ),


### PR DESCRIPTION
### Problem

The cross marker is drawn in a fixed white (`AppColors.headingDark`) on top of a full-opacity region colour. On the yellow region (`0xFFFFEB3B`) that leaves very little contrast and the cross is hard to make out — both the manually placed X and the smaller auto-cross.

### Change

Derive the marker colour from the region's relative luminance instead of hardcoding white, and flip the drop shadow to match so the dark cross still separates from the background.

```dart
final bool onLightRegion = widget.regionColor.computeLuminance() > 0.6;
final Color crossColor = onLightRegion ? AppColors.headingWhite : activeIconColor;
```

I used a luminance test rather than comparing against the yellow constant so it keeps working if the palette changes. Of the twelve colours in `queensColors` only yellow is above the threshold — it scores 0.81, and the next brightest (lime, `0xFF8BC34A`) is 0.45 — so this is a no-op on every other region today.

The queen/crown is left alone; happy to fold that in if you'd like it to match.

### Testing

I wasn't able to build this locally (no Dart toolchain on the machine I wrote it on), so it has only been reviewed by reading. It's a small self-contained change to `_buildContent`, but worth a look on-device before merging.